### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore` to prevent git worktree contents from being tracked in the repository

## Test plan
- [x] Verify `.worktrees/` directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)