### PR TITLE
style: apply ruff lint fixes and formatting

### DIFF
--- a/bot/core/bot.py
+++ b/bot/core/bot.py
@@ -7,44 +7,45 @@ from bot.core.health_server import start_health_server
 
 from bot.core.user.decorators import handle_permission_error
 
+
 class AnisecordBot(commands.Bot):
     """Anisecord Discord Bot with Extension support."""
-    
+
     def __init__(self):
         # Load environment variables
         load_dotenv()
-        
+
         # Bot configuration
         self.token = os.environ.get("DISCORD_BOT_TOKEN")
         self.gemini_api_key = os.environ.get("GEMINI_API_KEY")
         self.port = int(os.environ.get("PORT", 8080))
-        
+
         # Initialize bot
         intents = Intents.default()
         intents.message_content = True
         super().__init__(command_prefix=None, intents=intents)
-    
+
     async def setup_hook(self):
         """Called when the bot is starting up. Load extensions here."""
         print("Setting up bot extensions...")
-        
+
         # Set global error handler for app commands
         self.tree.on_error = self.on_app_command_error
-        
+
         # Load OSS extensions
         oss_extensions = [
-            'bot.features.common.basic_commands',
-            'bot.features.nutrition.cog',
-            'bot.features.sns_x.cog'
+            "bot.features.common.basic_commands",
+            "bot.features.nutrition.cog",
+            "bot.features.sns_x.cog",
         ]
-        
+
         for extension in oss_extensions:
             try:
                 await self.load_extension(extension)
                 print(f"Loaded extension: {extension}")
             except Exception as e:
                 print(f"Failed to load extension {extension}: {e}")
-        
+
         # Sync application commands
         try:
             synced = await self.tree.sync()
@@ -52,27 +53,29 @@ class AnisecordBot(commands.Bot):
         except Exception as e:
             print(f"Failed to sync commands: {e}")
 
-    async def on_app_command_error(self, interaction: Interaction, error: app_commands.AppCommandError):
+    async def on_app_command_error(
+        self, interaction: Interaction, error: app_commands.AppCommandError
+    ):
         """Global error handler for application commands."""
         # Try to handle permission errors via User module
         if await handle_permission_error(interaction, error):
             return
 
         print(f"Ignoring exception in command {interaction.command}: {error}")
-    
+
     async def on_ready(self):
         """Called when the bot is ready."""
-        print(f'Logged in as: {self.user}')
+        print(f"Logged in as: {self.user}")
 
 
 def main():
     """Main entry point for the bot."""
     bot = AnisecordBot()
-    
+
     # Start health check server
     print(f"Starting health check server on port {bot.port}...")
     start_health_server(bot.port)
-    
+
     try:
         # Start the Discord bot
         print("Starting Discord bot...")

--- a/bot/core/health_server.py
+++ b/bot/core/health_server.py
@@ -23,7 +23,7 @@ def create_health_server(port: int = 8080) -> FastAPI:
         Returns only status code 200 OK without response body.
         """
         return Response(status_code=200)
-    
+
     return app
 
 
@@ -37,17 +37,18 @@ def run_fastapi_server(app: FastAPI, port: int):
 def start_health_server(port: int = 8080) -> threading.Thread:
     """
     Start the FastAPI health server in a background thread.
-    
+
     DESIGN PRINCIPLE: The health check server must not block the main bot process.
     Using a daemon thread is crucial. A daemon thread will exit automatically
     when the main thread (the bot) exits. This prevents a "zombie process"
     where the health check server stays alive after the bot has crashed.
     """
     app = create_health_server(port)
-    api_thread = threading.Thread(target=run_fastapi_server, args=(app, port), daemon=True)
+    api_thread = threading.Thread(
+        target=run_fastapi_server, args=(app, port), daemon=True
+    )
     api_thread.start()
-    
-    time.sleep(2)  # Allow time for the server to start
-    
-    return api_thread
 
+    time.sleep(2)  # Allow time for the server to start
+
+    return api_thread

--- a/bot/core/user/decorators.py
+++ b/bot/core/user/decorators.py
@@ -1,40 +1,46 @@
 from discord import Interaction, app_commands
-from discord.ext import commands
 from .repository import UserRepository
+
 
 class FeatureAccessDenied(app_commands.CheckFailure):
     """Exception raised when a user does not have access to a feature."""
+
     def __init__(self, feature_name: str):
         self.feature_name = feature_name
         super().__init__(f"Access denied for feature: {feature_name}")
 
-async def handle_permission_error(interaction: Interaction, error: app_commands.AppCommandError):
+
+async def handle_permission_error(
+    interaction: Interaction, error: app_commands.AppCommandError
+):
     """
     Handle permission errors (FeatureAccessDenied) from feature_enabled decorator.
     """
     if isinstance(error, FeatureAccessDenied):
         await interaction.response.send_message(
-            f"🚫 **Access Denied**: You do not have permission to use the `{error.feature_name}` feature.", 
-            ephemeral=True
+            f"🚫 **Access Denied**: You do not have permission to use the `{error.feature_name}` feature.",
+            ephemeral=True,
         )
-        return True # Handled
-    return False # Not handled
+        return True  # Handled
+    return False  # Not handled
+
 
 def feature_enabled(feature_name: str):
     """
     Decorator to check if a feature is enabled for the user.
     """
+
     async def predicate(interaction: Interaction) -> bool:
         # NOTE: app_commands.check predicate receives Interaction, not Context
         repo = UserRepository()
-        
+
         user_id = str(interaction.user.id)
         user = repo.get_user(user_id)
-        
+
         if feature_name in user.allowed_features:
             return True
-        
+
         # Raise specific exception instead of returning False
         raise FeatureAccessDenied(feature_name)
-        
+
     return app_commands.check(predicate)

--- a/bot/core/user/domain.py
+++ b/bot/core/user/domain.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
-from typing import List
+
 
 @dataclass(frozen=True)
 class User:
     user_id: str
     timezone: str = "Asia/Tokyo"
     language: str = "ja"
-    allowed_features: tuple[str, ...] = ("sns-x", "nutrition") # Default enabled for now
+    allowed_features: tuple[str, ...] = (
+        "sns-x",
+        "nutrition",
+    )  # Default enabled for now

--- a/bot/core/user/repository.py
+++ b/bot/core/user/repository.py
@@ -1,5 +1,5 @@
-from typing import Optional
 from .domain import User
+
 
 class UserRepository:
     def get_user(self, user_id: str) -> User:

--- a/bot/features/common/basic_commands.py
+++ b/bot/features/common/basic_commands.py
@@ -11,10 +11,11 @@ class BasicCommandsCog(commands.Cog):
     @app_commands.command(name="ping", description="Test bot response time.")
     async def ping(self, interaction: Interaction):
         """Test bot response time."""
-        await interaction.response.send_message(f'Pong! ({round(self.bot.latency * 1000)}ms)')
+        await interaction.response.send_message(
+            f"Pong! ({round(self.bot.latency * 1000)}ms)"
+        )
 
 
 async def setup(bot):
     """Setup function to add the cog to the bot."""
     await bot.add_cog(BasicCommandsCog(bot))
-

--- a/bot/features/nutrition/cog.py
+++ b/bot/features/nutrition/cog.py
@@ -2,11 +2,14 @@ import traceback
 from discord import Interaction, app_commands, Attachment
 from discord.ext import commands
 
+from bot.core.user.decorators import feature_enabled
 from bot.services.llm.repository import LLMRepository
 from bot.services.llm.utils import download_and_encode_image
 
 
-def create_nutrition_coaching_prompt(description: str = None, image_count: int = 0) -> str:
+def create_nutrition_coaching_prompt(
+    description: str = None, image_count: int = 0
+) -> str:
     """Create structured prompt for nutrition coaching."""
     base_prompt = """As a nutrition coach, analyze the meal(s) and provide nutritional guidance. Focus specifically on:
 
@@ -33,28 +36,30 @@ Format your response EXACTLY as follows:
 
     if description:
         base_prompt = f"User description: {description}\n\n" + base_prompt
-    
+
     if image_count == 0:
-        base_prompt = base_prompt.replace("📸 **分析画像数: [NUMBER]枚**", "📸 **テキスト説明のみでコーチング**")
+        base_prompt = base_prompt.replace(
+            "📸 **分析画像数: [NUMBER]枚**", "📸 **テキスト説明のみでコーチング**"
+        )
     else:
         base_prompt = base_prompt.replace("[NUMBER]", str(image_count))
-    
+
     return base_prompt
 
 
-from bot.core.user.decorators import feature_enabled
-
 class NutritionCoachCog(commands.Cog):
     """Nutrition coaching functionality using Gemini AI."""
-    
+
     def __init__(self, bot):
         self.bot = bot
         self.llm_repository = LLMRepository(
-            model_name="gemini/gemini-2.5-flash",
-            api_key=self.bot.gemini_api_key
+            model_name="gemini/gemini-2.5-flash", api_key=self.bot.gemini_api_key
         )
 
-    @app_commands.command(name="meal", description="Get nutrition coaching for your meal photos and/or description.")
+    @app_commands.command(
+        name="meal",
+        description="Get nutrition coaching for your meal photos and/or description.",
+    )
     @feature_enabled("nutrition")
     @app_commands.describe(
         description="Text description of the meal (optional if images are provided)",
@@ -62,7 +67,7 @@ class NutritionCoachCog(commands.Cog):
         image2="Second meal photo (optional)",
         image3="Third meal photo (optional)",
         image4="Fourth meal photo (optional)",
-        image5="Fifth meal photo (optional)"
+        image5="Fifth meal photo (optional)",
     )
     async def meal(
         self,
@@ -72,31 +77,39 @@ class NutritionCoachCog(commands.Cog):
         image2: Attachment = None,
         image3: Attachment = None,
         image4: Attachment = None,
-        image5: Attachment = None
+        image5: Attachment = None,
     ):
         """Get nutrition coaching for your meal."""
         # Defer response to prevent timeout
         await interaction.response.defer()
 
         # Collect all provided images
-        images = [img for img in [image1, image2, image3, image4, image5] if img is not None]
-        
+        images = [
+            img for img in [image1, image2, image3, image4, image5] if img is not None
+        ]
+
         # Validate that at least one input is provided
         if not description and not images:
-            await interaction.followup.send("❌ Please provide either a meal description or at least one image.")
+            await interaction.followup.send(
+                "❌ Please provide either a meal description or at least one image."
+            )
             return
 
         # Validate image formats
-        supported_formats = ['.jpg', '.jpeg', '.png', '.webp']
+        supported_formats = [".jpg", ".jpeg", ".png", ".webp"]
         for image in images:
-            if not any(image.filename.lower().endswith(fmt) for fmt in supported_formats):
-                await interaction.followup.send(f"❌ Unsupported image format: {image.filename}. Please use JPG, PNG, or WebP.")
+            if not any(
+                image.filename.lower().endswith(fmt) for fmt in supported_formats
+            ):
+                await interaction.followup.send(
+                    f"❌ Unsupported image format: {image.filename}. Please use JPG, PNG, or WebP."
+                )
                 return
 
         try:
             # Prepare message content
             content = []
-            
+
             # Add text description if provided
             prompt_text = create_nutrition_coaching_prompt(description, len(images))
             content.append({"type": "text", "text": prompt_text})
@@ -104,33 +117,39 @@ class NutritionCoachCog(commands.Cog):
             # Process and add images
             print(f"Processing {len(images)} images for meal coaching")
             for i, image in enumerate(images):
-                print(f"Downloading and encoding image {i+1}: {image.filename}")
+                print(f"Downloading and encoding image {i + 1}: {image.filename}")
                 base64_image = await download_and_encode_image(image.url)
-                
+
                 # Determine content type from filename
-                if image.filename.lower().endswith(('.jpg', '.jpeg')):
+                if image.filename.lower().endswith((".jpg", ".jpeg")):
                     content_type = "image/jpeg"
-                elif image.filename.lower().endswith('.png'):
+                elif image.filename.lower().endswith(".png"):
                     content_type = "image/png"
-                elif image.filename.lower().endswith('.webp'):
+                elif image.filename.lower().endswith(".webp"):
                     content_type = "image/webp"
                 else:
                     content_type = "image/jpeg"  # fallback
-                
-                content.append({
-                    "type": "image_url",
-                    "image_url": {"url": f"data:{content_type};base64,{base64_image}"}
-                })
+
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": f"data:{content_type};base64,{base64_image}"
+                        },
+                    }
+                )
 
             # Call Gemini API
             print("Calling Gemini API for meal coaching via Repository")
             response_text = await self.llm_repository.generate_content(content)
             print("Received meal coaching from Gemini")
 
-        except Exception as e:
+        except Exception:
             print("An error occurred with the meal coaching API call.")
             traceback.print_exc()
-            await interaction.followup.send("❌ An error occurred while providing coaching for your meal. Please try again later.")
+            await interaction.followup.send(
+                "❌ An error occurred while providing coaching for your meal. Please try again later."
+            )
             return
 
         await interaction.followup.send(response_text)
@@ -139,4 +158,3 @@ class NutritionCoachCog(commands.Cog):
 async def setup(bot):
     """Setup function to add the cog to the bot."""
     await bot.add_cog(NutritionCoachCog(bot))
-

--- a/bot/features/sns_x/cog.py
+++ b/bot/features/sns_x/cog.py
@@ -10,34 +10,36 @@ from bot.core.user.repository import UserRepository
 from .domain import SnsXDomain, SnsXDraft
 from .repository import SnsXConfigRepository
 
+
 class SnsxCog(commands.Cog):
     """Generate X (Twitter) drafts from channel history."""
 
     def __init__(self, bot):
         self.bot = bot
-        
+
         # Dependencies
         self.llm_repository = LLMRepository(
-            model_name="gemini/gemini-2.5-flash",
-            api_key=self.bot.gemini_api_key
+            model_name="gemini/gemini-2.5-flash", api_key=self.bot.gemini_api_key
         )
         self.discord_repository = DiscordRepository()
         self.user_repository = UserRepository()
         self.config_repository = SnsXConfigRepository()
 
-    @app_commands.command(name="sns-x", description="Generate an X post draft from messages.")
+    @app_commands.command(
+        name="sns-x", description="Generate an X post draft from messages."
+    )
     @feature_enabled("sns-x")
     @app_commands.describe(
         date_from="Start date (YYYY-MM-DD). Default: 24 hours ago.",
         date_to="End date (YYYY-MM-DD). Default: Now.",
-        language="Output language (e.g. ja, en). Default: User setting."
+        language="Output language (e.g. ja, en). Default: User setting.",
     )
     async def sns_x(
-        self, 
-        interaction: Interaction, 
-        date_from: str = None, 
+        self,
+        interaction: Interaction,
+        date_from: str = None,
         date_to: str = None,
-        language: str = None
+        language: str = None,
     ):
         """
         Generate an X post draft from messages in a specified range or last 24 hours.
@@ -49,13 +51,13 @@ class SnsxCog(commands.Cog):
             user = self.user_repository.get_user(str(interaction.user.id))
             # Get Feature Config
             config = self.config_repository.get_config(str(interaction.user.id))
-            
+
             tz = zoneinfo.ZoneInfo(user.timezone)
             target_lang = language or user.language
 
             # Determine Time Range
             now = datetime.datetime.now(tz)
-            
+
             # Default: Last 24 hours (UTC calculation safe, but better to be explicit)
             start_dt = None
             end_dt = None
@@ -65,9 +67,13 @@ class SnsxCog(commands.Cog):
                     # Parse YYYY-MM-DD in User's Timezone
                     d_from = datetime.datetime.strptime(date_from, "%Y-%m-%d").date()
                     # Start of that day
-                    start_dt = datetime.datetime.combine(d_from, datetime.time.min, tzinfo=tz)
+                    start_dt = datetime.datetime.combine(
+                        d_from, datetime.time.min, tzinfo=tz
+                    )
                 except ValueError:
-                    await interaction.followup.send("❌ Invalid date_from format. Use YYYY-MM-DD.")
+                    await interaction.followup.send(
+                        "❌ Invalid date_from format. Use YYYY-MM-DD."
+                    )
                     return
             else:
                 # Default to 24 hours ago from now
@@ -76,11 +82,15 @@ class SnsxCog(commands.Cog):
             if date_to:
                 try:
                     d_to = datetime.datetime.strptime(date_to, "%Y-%m-%d").date()
-                    # End of that day (or start of next day?) Usually users expect inclusive. 
+                    # End of that day (or start of next day?) Usually users expect inclusive.
                     # Let's set it to end of day 23:59:59
-                    end_dt = datetime.datetime.combine(d_to, datetime.time.max, tzinfo=tz)
+                    end_dt = datetime.datetime.combine(
+                        d_to, datetime.time.max, tzinfo=tz
+                    )
                 except ValueError:
-                    await interaction.followup.send("❌ Invalid date_to format. Use YYYY-MM-DD.")
+                    await interaction.followup.send(
+                        "❌ Invalid date_to format. Use YYYY-MM-DD."
+                    )
                     return
             else:
                 # Default to Now
@@ -92,30 +102,34 @@ class SnsxCog(commands.Cog):
 
             # Fetch messages
             messages = await self.discord_repository.fetch_messages(
-                channel=interaction.channel, 
-                after=start_dt,
-                before=end_dt
+                channel=interaction.channel, after=start_dt, before=end_dt
             )
-            
+
             if not messages:
-                await interaction.followup.send(f"**X Post Draft**\nTime: {time_range_str}\n\nNo messages found in this period.")
+                await interaction.followup.send(
+                    f"**X Post Draft**\nTime: {time_range_str}\n\nNo messages found in this period."
+                )
                 return
 
             # Generate draft
-            prompt = SnsXDomain.create_draft_prompt(messages, persona=config.persona, language=target_lang)
+            prompt = SnsXDomain.create_draft_prompt(
+                messages, persona=config.persona, language=target_lang
+            )
             content = await self.llm_repository.generate_content(prompt)
             draft = SnsXDraft(content=content, source_posts_count=len(messages))
-            
+
             response_text = f"**X Post Draft ({target_lang})**\nTime: {time_range_str}\nMessages: {draft.source_posts_count}\n\n{draft.content}"
             if len(response_text) > 2000:
                 response_text = response_text[:1900] + "\n...(truncated)"
-                
+
             await interaction.followup.send(response_text)
-            
+
         except Exception as e:
             await interaction.followup.send(f"❌ An error occurred: {e}")
 
-    @app_commands.command(name="sns-x-today", description="Generate an X post draft for today's messages.")
+    @app_commands.command(
+        name="sns-x-today", description="Generate an X post draft for today's messages."
+    )
     @feature_enabled("sns-x")
     @app_commands.describe(
         language="Output language (e.g. ja, en). Default: User setting."
@@ -136,35 +150,40 @@ class SnsxCog(commands.Cog):
 
             # "Today" means from 00:00 (User TZ) to Now
             now = datetime.datetime.now(tz)
-            start_dt = datetime.datetime.combine(now.date(), datetime.time.min, tzinfo=tz)
+            start_dt = datetime.datetime.combine(
+                now.date(), datetime.time.min, tzinfo=tz
+            )
             end_dt = now
 
             time_range_str = f"{start_dt.strftime('%Y-%m-%d %H:%M')} - {end_dt.strftime('%Y-%m-%d %H:%M')} ({user.timezone})"
             print(f"Fetching messages for {time_range_str} (Today)")
 
             messages = await self.discord_repository.fetch_messages(
-                channel=interaction.channel, 
-                after=start_dt,
-                before=end_dt
+                channel=interaction.channel, after=start_dt, before=end_dt
             )
-            
+
             if not messages:
-                await interaction.followup.send(f"**X Post Draft (Today)**\nTime: {time_range_str}\n\nNo messages found today.")
+                await interaction.followup.send(
+                    f"**X Post Draft (Today)**\nTime: {time_range_str}\n\nNo messages found today."
+                )
                 return
 
             # Generate draft
-            prompt = SnsXDomain.create_draft_prompt(messages, persona=config.persona, language=target_lang)
+            prompt = SnsXDomain.create_draft_prompt(
+                messages, persona=config.persona, language=target_lang
+            )
             content = await self.llm_repository.generate_content(prompt)
             draft = SnsXDraft(content=content, source_posts_count=len(messages))
-            
+
             response_text = f"**X Post Draft (Today, {target_lang})**\nTime: {time_range_str}\nMessages: {draft.source_posts_count}\n\n{draft.content}"
             if len(response_text) > 2000:
                 response_text = response_text[:1900] + "\n...(truncated)"
-                
+
             await interaction.followup.send(response_text)
-            
+
         except Exception as e:
             await interaction.followup.send(f"❌ An error occurred: {e}")
+
 
 async def setup(bot):
     await bot.add_cog(SnsxCog(bot))

--- a/bot/features/sns_x/domain.py
+++ b/bot/features/sns_x/domain.py
@@ -2,19 +2,24 @@ from dataclasses import dataclass
 from typing import List
 from bot.services.discord.domain import DiscordPost
 
+
 @dataclass
 class SnsXDraft:
     content: str
     source_posts_count: int
+
 
 @dataclass
 class SnsXConfig:
     user_id: str
     persona: str = "An official account for a solo developer. Professional yet friendly and engaging."
 
+
 class SnsXDomain:
     @staticmethod
-    def create_draft_prompt(messages: List[DiscordPost], persona: str, language: str = "ja") -> str:
+    def create_draft_prompt(
+        messages: List[DiscordPost], persona: str, language: str = "ja"
+    ) -> str:
         """
         Create the LLM prompt for generating an X post draft.
         """
@@ -22,16 +27,18 @@ class SnsXDomain:
         for msg in messages:
             # Format: [Time] User: Content
             # Note: Explicitly excluding attachments here as requested.
-            base_info = f"[{msg.posted_at.strftime('%Y-%m-%d %H:%M')}] {msg.author_name}"
-            
+            base_info = (
+                f"[{msg.posted_at.strftime('%Y-%m-%d %H:%M')}] {msg.author_name}"
+            )
+
             if msg.thread_name:
                 base_info += f" (in Thread: {msg.thread_name})"
-                
+
             line = f"{base_info}: {msg.content}"
             formatted_lines.append(line)
-        
+
         formatted_log = "\n".join(formatted_lines)
-        
+
         prompt = f"""
 You are a skilled social media manager. 
 Create an engaging post for X (formerly Twitter) based on the following chat log from a Discord server.

--- a/bot/features/sns_x/repository.py
+++ b/bot/features/sns_x/repository.py
@@ -1,5 +1,6 @@
 from .domain import SnsXConfig
 
+
 class SnsXConfigRepository:
     def get_config(self, user_id: str) -> SnsXConfig:
         """
@@ -9,5 +10,5 @@ class SnsXConfigRepository:
         # TODO: Retrieve from persistence layer
         return SnsXConfig(
             user_id=user_id,
-            persona="個人事業主の公式アカウントとして振る舞ってください。プロフェッショナルでありながら、親しみやすさを持ち、読者に有益な情報や活動の様子を伝えてください。あまり大げさな表現は避け、誠実なトーンを維持してください。"
+            persona="個人事業主の公式アカウントとして振る舞ってください。プロフェッショナルでありながら、親しみやすさを持ち、読者に有益な情報や活動の様子を伝えてください。あまり大げさな表現は避け、誠実なトーンを維持してください。",
         )

--- a/bot/services/discord/domain.py
+++ b/bot/services/discord/domain.py
@@ -2,9 +2,11 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 import datetime
 
+
 @dataclass(frozen=True)
 class DiscordPost:
     """Class representing a single Discord message."""
+
     author_name: str
     content: str
     posted_at: datetime.datetime

--- a/bot/services/discord/repository.py
+++ b/bot/services/discord/repository.py
@@ -3,17 +3,18 @@ import datetime
 from typing import List, Optional
 from .domain import DiscordPost
 
+
 class DiscordRepository:
     async def fetch_messages(
-        self, 
-        channel: discord.TextChannel, 
-        after: datetime.datetime, 
+        self,
+        channel: discord.TextChannel,
+        after: datetime.datetime,
         before: Optional[datetime.datetime] = None,
-        limit: int = 2000
+        limit: int = 2000,
     ) -> List[DiscordPost]:
         """
         Fetch messages from a Discord channel history within a date range.
-        
+
         Args:
             channel: The text channel to fetch from.
             after: Fetch messages after this datetime (oldest limit).
@@ -21,54 +22,60 @@ class DiscordRepository:
             limit: Max messages to fetch. Discord API defaults to 100 per request, library handles pagination.
         """
         posts = []
-        
+
         # 1. Fetch from Main Channel
-        async for msg in channel.history(limit=limit, after=after, before=before, oldest_first=True):
+        async for msg in channel.history(
+            limit=limit, after=after, before=before, oldest_first=True
+        ):
             if msg.author.bot:
                 continue
             posts.append(self._to_discord_post(msg))
 
         # 2. Identify Threads to check (Active + Archived)
         threads_to_check = []
-        if hasattr(channel, 'threads'):
-             threads_to_check = list(channel.threads) # Active threads
-        
-             # Add archived threads modified after start time
-             try:
-                  async for thread in channel.archived_threads(after=after):
-                      threads_to_check.append(thread)
-             except Exception as e:
-                 print(f"Failed to fetch archived threads: {e}")
+        if hasattr(channel, "threads"):
+            threads_to_check = list(channel.threads)  # Active threads
+
+            # Add archived threads modified after start time
+            try:
+                async for thread in channel.archived_threads(after=after):
+                    threads_to_check.append(thread)
+            except Exception as e:
+                print(f"Failed to fetch archived threads: {e}")
 
         # 3. Fetch from Threads
         for thread in threads_to_check:
             # We use the same time range for threads
             try:
-                async for msg in thread.history(limit=limit, after=after, before=before, oldest_first=True):
+                async for msg in thread.history(
+                    limit=limit, after=after, before=before, oldest_first=True
+                ):
                     if msg.author.bot:
                         continue
                     posts.append(self._to_discord_post(msg, thread_name=thread.name))
             except discord.Forbidden:
-                continue # Skip threads we can't read
+                continue  # Skip threads we can't read
             except Exception as e:
                 print(f"Error reading thread {thread.name}: {e}")
 
         # 4. Sort by time (oldest first)
         posts.sort(key=lambda p: p.posted_at)
-        
+
         return posts
 
-    def _to_discord_post(self, msg: discord.Message, thread_name: str = None) -> DiscordPost:
+    def _to_discord_post(
+        self, msg: discord.Message, thread_name: str = None
+    ) -> DiscordPost:
         """Helper to convert discord.Message to DiscordPost."""
         content = msg.content
-            
+
         attachment_urls = [a.url for a in msg.attachments]
-            
+
         return DiscordPost(
             author_name=msg.author.display_name,
             content=content,
             posted_at=msg.created_at,
             message_id=str(msg.id),
             thread_name=thread_name,
-            attachment_urls=attachment_urls
+            attachment_urls=attachment_urls,
         )

--- a/bot/services/github/repository.py
+++ b/bot/services/github/repository.py
@@ -118,7 +118,9 @@ class GitHubRepository:
     async def fetch_milestones(self, repo: str) -> list[GitHubMilestone]:
         """Fetch open milestones for a repo."""
         data = await self._request(
-            "GET", f"/repos/{repo}/milestones", params={"state": "open", "sort": "due_on"}
+            "GET",
+            f"/repos/{repo}/milestones",
+            params={"state": "open", "sort": "due_on"},
         )
         return [_to_milestone(m) for m in data]
 
@@ -137,9 +139,7 @@ class GitHubRepository:
             if "pull_request" not in item or item["pull_request"] is None
         ]
 
-    async def fetch_issues_without_milestone(
-        self, repo: str
-    ) -> list[GitHubIssue]:
+    async def fetch_issues_without_milestone(self, repo: str) -> list[GitHubIssue]:
         """Fetch open assigned issues without a milestone (Backlog)."""
         data = await self._request(
             "GET",

--- a/bot/services/llm/repository.py
+++ b/bot/services/llm/repository.py
@@ -1,11 +1,12 @@
 import litellm
 from typing import Union, List, Dict, Any
 
+
 class LLMRepository:
     def __init__(self, model_name: str, api_key: str):
         """
         Initialize the LLM Repository.
-        
+
         Args:
             model_name (str): The model identifier for litellm (e.g. 'gemini/gemini-2.5-flash').
             api_key (str): The API key for the LLM provider.
@@ -13,7 +14,9 @@ class LLMRepository:
         self.model_name = model_name
         self.api_key = api_key
 
-    async def generate_content(self, input_content: Union[str, List[Dict[str, Any]]]) -> str:
+    async def generate_content(
+        self, input_content: Union[str, List[Dict[str, Any]]]
+    ) -> str:
         """
         Generate content using the configured LLM.
 
@@ -24,16 +27,16 @@ class LLMRepository:
             str: The generated response text.
         """
         try:
-            # Wrap string prompt in list of dicts for litellm consistency if needed, 
-            # but litellm handles string prompt too. 
+            # Wrap string prompt in list of dicts for litellm consistency if needed,
+            # but litellm handles string prompt too.
             # However, for consistency with 'messages' format:
             messages = [{"role": "user", "content": input_content}]
-            
+
             response = await litellm.acompletion(
                 model=self.model_name,
                 messages=messages,
                 api_key=self.api_key,
-                num_retries=3  # Retry on 503/Overload errors
+                num_retries=3,  # Retry on 503/Overload errors
             )
             return response.choices[0].message.content
         except Exception as e:

--- a/bot/services/llm/utils.py
+++ b/bot/services/llm/utils.py
@@ -1,6 +1,7 @@
 import base64
 import httpx
 
+
 async def download_and_encode_image(url: str) -> str:
     """Download image from URL and return base64 encoded string."""
     try:
@@ -8,9 +9,11 @@ async def download_and_encode_image(url: str) -> str:
             response = await client.get(url)
             if response.status_code == 200:
                 image_data = response.content
-                return base64.b64encode(image_data).decode('utf-8')
+                return base64.b64encode(image_data).decode("utf-8")
             else:
-                raise Exception(f"Failed to download image: HTTP {response.status_code}")
+                raise Exception(
+                    f"Failed to download image: HTTP {response.status_code}"
+                )
     except Exception as e:
         print(f"Error downloading image: {e}")
         raise

--- a/bot/services/ticktick/domain.py
+++ b/bot/services/ticktick/domain.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 class TaskPriority(IntEnum):
     """TickTick API priority values."""
+
     NONE = 0
     LOW = 1
     MEDIUM = 3
@@ -14,12 +15,14 @@ class TaskPriority(IntEnum):
 
 class TaskStatus(IntEnum):
     """TickTick API task status values."""
+
     ACTIVE = 0
     COMPLETED = 2
 
 
 class SubTaskStatus(IntEnum):
     """TickTick API subtask (checklist item) status values."""
+
     ACTIVE = 0
     COMPLETED = 1
 

--- a/tests/services/github/test_repository.py
+++ b/tests/services/github/test_repository.py
@@ -1,8 +1,8 @@
-from datetime import date, datetime
+from datetime import date
 
 from aioresponses import aioresponses
 
-from bot.services.github.domain import GitHubIssue, GitHubMilestone
+from bot.services.github.domain import GitHubMilestone
 from bot.services.github.repository import GitHubRepository
 
 API_BASE = "https://api.github.com"
@@ -143,7 +143,9 @@ class TestRequest:
                 page2_url,
                 payload=[{"number": 2}],
             )
-            result = await repo._request("GET", "/repos/owner/repo1/issues", params={"state": "open"})
+            result = await repo._request(
+                "GET", "/repos/owner/repo1/issues", params={"state": "open"}
+            )
 
         assert len(result) == 2
         assert result[0]["number"] == 1
@@ -256,14 +258,32 @@ class TestFetchActionableIssues:
 
         with aioresponses() as m:
             # repo1 milestones + issues
-            m.get(f"{API_BASE}/repos/owner/repo1/milestones?state=open&sort=due_on", payload=[SAMPLE_MILESTONES[0]])
-            m.get(f"{API_BASE}/repos/owner/repo1/issues?milestone=1&state=open", payload=SAMPLE_ISSUES)
-            m.get(f"{API_BASE}/repos/owner/repo1/issues?milestone=none&state=open&assignee=%2A", payload=SAMPLE_BACKLOG_ISSUES)
+            m.get(
+                f"{API_BASE}/repos/owner/repo1/milestones?state=open&sort=due_on",
+                payload=[SAMPLE_MILESTONES[0]],
+            )
+            m.get(
+                f"{API_BASE}/repos/owner/repo1/issues?milestone=1&state=open",
+                payload=SAMPLE_ISSUES,
+            )
+            m.get(
+                f"{API_BASE}/repos/owner/repo1/issues?milestone=none&state=open&assignee=%2A",
+                payload=SAMPLE_BACKLOG_ISSUES,
+            )
 
             # repo2 milestones + issues
-            m.get(f"{API_BASE}/repos/owner/repo2/milestones?state=open&sort=due_on", payload=SAMPLE_MILESTONES_REPO2)
-            m.get(f"{API_BASE}/repos/owner/repo2/issues?milestone=1&state=open", payload=SAMPLE_ISSUES_REPO2)
-            m.get(f"{API_BASE}/repos/owner/repo2/issues?milestone=none&state=open&assignee=%2A", payload=[])
+            m.get(
+                f"{API_BASE}/repos/owner/repo2/milestones?state=open&sort=due_on",
+                payload=SAMPLE_MILESTONES_REPO2,
+            )
+            m.get(
+                f"{API_BASE}/repos/owner/repo2/issues?milestone=1&state=open",
+                payload=SAMPLE_ISSUES_REPO2,
+            )
+            m.get(
+                f"{API_BASE}/repos/owner/repo2/issues?milestone=none&state=open&assignee=%2A",
+                payload=[],
+            )
 
             issues = await repo.fetch_actionable_issues()
 
@@ -277,8 +297,14 @@ class TestFetchActionableIssues:
         repo = make_repo(repos=["owner/empty"])
 
         with aioresponses() as m:
-            m.get(f"{API_BASE}/repos/owner/empty/milestones?state=open&sort=due_on", payload=[])
-            m.get(f"{API_BASE}/repos/owner/empty/issues?milestone=none&state=open&assignee=%2A", payload=[])
+            m.get(
+                f"{API_BASE}/repos/owner/empty/milestones?state=open&sort=due_on",
+                payload=[],
+            )
+            m.get(
+                f"{API_BASE}/repos/owner/empty/issues?milestone=none&state=open&assignee=%2A",
+                payload=[],
+            )
 
             issues = await repo.fetch_actionable_issues()
 
@@ -288,9 +314,18 @@ class TestFetchActionableIssues:
         repo = make_repo(repos=["owner/repo1"])
 
         with aioresponses() as m:
-            m.get(f"{API_BASE}/repos/owner/repo1/milestones?state=open&sort=due_on", payload=[SAMPLE_MILESTONES[0]])
-            m.get(f"{API_BASE}/repos/owner/repo1/issues?milestone=1&state=open", payload=SAMPLE_ISSUES)
-            m.get(f"{API_BASE}/repos/owner/repo1/issues?milestone=none&state=open&assignee=%2A", payload=[])
+            m.get(
+                f"{API_BASE}/repos/owner/repo1/milestones?state=open&sort=due_on",
+                payload=[SAMPLE_MILESTONES[0]],
+            )
+            m.get(
+                f"{API_BASE}/repos/owner/repo1/issues?milestone=1&state=open",
+                payload=SAMPLE_ISSUES,
+            )
+            m.get(
+                f"{API_BASE}/repos/owner/repo1/issues?milestone=none&state=open&assignee=%2A",
+                payload=[],
+            )
 
             issues = await repo.fetch_actionable_issues()
 

--- a/tests/services/ticktick/test_domain.py
+++ b/tests/services/ticktick/test_domain.py
@@ -30,13 +30,17 @@ class TestSubTaskStatus:
 
 class TestTickTickSubTask:
     def test_creation(self):
-        sub = TickTickSubTask(title="Buy milk", status=SubTaskStatus.ACTIVE, sort_order=0)
+        sub = TickTickSubTask(
+            title="Buy milk", status=SubTaskStatus.ACTIVE, sort_order=0
+        )
         assert sub.title == "Buy milk"
         assert sub.status == SubTaskStatus.ACTIVE
         assert sub.sort_order == 0
 
     def test_frozen(self):
-        sub = TickTickSubTask(title="Buy milk", status=SubTaskStatus.ACTIVE, sort_order=0)
+        sub = TickTickSubTask(
+            title="Buy milk", status=SubTaskStatus.ACTIVE, sort_order=0
+        )
         try:
             sub.title = "changed"
             assert False, "Should be frozen"
@@ -68,7 +72,9 @@ class TestTickTickTask:
     def test_creation_with_all_fields(self):
         from datetime import datetime
 
-        sub = TickTickSubTask(title="Step 1", status=SubTaskStatus.COMPLETED, sort_order=0)
+        sub = TickTickSubTask(
+            title="Step 1", status=SubTaskStatus.COMPLETED, sort_order=0
+        )
         task = TickTickTask(
             id="task2",
             title="Full task",
@@ -93,8 +99,13 @@ class TestTickTickTask:
 
     def test_frozen(self):
         task = TickTickTask(
-            id="t", title="t", project_id="p", project_name="P",
-            status=TaskStatus.ACTIVE, priority=TaskPriority.NONE, is_overdue=False,
+            id="t",
+            title="t",
+            project_id="p",
+            project_name="P",
+            status=TaskStatus.ACTIVE,
+            priority=TaskPriority.NONE,
+            is_overdue=False,
         )
         try:
             task.title = "changed"


### PR DESCRIPTION
## Summary
- Fix 7 ruff lint errors: 5 unused imports (F401), 1 unused variable (F841), 1 import ordering (E402)
- Apply ruff formatting to 18 files (consistent style across the codebase)
- All 48 tests pass, `ruff check` and `ruff format --check` clean

## Changes
- **Lint fixes**: Removed unused imports (`typing.List`, `typing.Optional`, `datetime.datetime`, `discord.ext.commands`, `GitHubIssue`), removed unused exception variable `e`, moved `feature_enabled` import to top of file
- **Formatting**: Applied consistent formatting (line length 88, trailing commas, string quoting, etc.)

## Test Plan
- [x] `uv run pytest -v` — 48 passed
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 39 files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)