### PR TITLE
chore: change default LLM model to gemini-2.5-flash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,7 +52,7 @@ DAILY_PLAN_CHANNEL_ID=
 # DAILY_PLAN_SCHEDULE_HOUR=7
 # DAILY_PLAN_SCHEDULE_MINUTE=0
 # LLM model for plan generation (any litellm-compatible model)
-# DAILY_PLAN_LLM_MODEL=gemini/gemini-3.1-pro-preview
+# DAILY_PLAN_LLM_MODEL=gemini/gemini-2.5-flash
 # Timezone for scheduling and date formatting
 # DAILY_PLAN_TIMEZONE=Asia/Tokyo
 # Enabled task/context sources (comma-separated: ticktick,github,google_calendar)

--- a/bot/features/daily_plan/repository.py
+++ b/bot/features/daily_plan/repository.py
@@ -20,7 +20,7 @@ class DailyPlanConfig:
     thread_format: str = "{date} 日報"
     schedule_hour: int = 7
     schedule_minute: int = 0
-    llm_model: str = "gemini/gemini-3.1-pro-preview"
+    llm_model: str = "gemini/gemini-2.5-flash"
     timezone: str = "Asia/Tokyo"
     sources: tuple[str, ...] = ("ticktick", "github")
 
@@ -71,7 +71,7 @@ class DailyPlanConfigRepository:
             schedule_hour=int(os.environ.get("DAILY_PLAN_SCHEDULE_HOUR", "7")),
             schedule_minute=int(os.environ.get("DAILY_PLAN_SCHEDULE_MINUTE", "0")),
             llm_model=os.environ.get(
-                "DAILY_PLAN_LLM_MODEL", "gemini/gemini-3.1-pro-preview"
+                "DAILY_PLAN_LLM_MODEL", "gemini/gemini-2.5-flash"
             ),
             timezone=os.environ.get("DAILY_PLAN_TIMEZONE", "Asia/Tokyo"),
             sources=tuple(s.strip() for s in sources_str.split(",") if s.strip()),

--- a/tests/features/daily_plan/test_repository.py
+++ b/tests/features/daily_plan/test_repository.py
@@ -17,7 +17,7 @@ class TestDailyPlanConfigRepository:
         assert config.thread_format == "{date} 日報"
         assert config.schedule_hour == 7
         assert config.schedule_minute == 0
-        assert config.llm_model == "gemini/gemini-3.1-pro-preview"
+        assert config.llm_model == "gemini/gemini-2.5-flash"
         assert config.timezone == "Asia/Tokyo"
         assert config.sources == ("ticktick", "github")
 


### PR DESCRIPTION
## Summary
- Change default LLM model from `gemini/gemini-3.1-pro-preview` to `gemini/gemini-2.5-flash`
- Preview model was frequently returning 503 errors due to high demand
- Flash is sufficient for daily plan generation and offers better stability, speed, and cost

## Test plan
- [x] `tests/features/daily_plan/test_repository.py` — 14 passed
- [x] Verify daily plan generation works with the new model on deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)