### PR TITLE
fix: URL-encode calendar IDs containing '#' in API requests

### DIFF
--- a/bot/services/google_calendar/repository.py
+++ b/bot/services/google_calendar/repository.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 from typing import Any
+from urllib.parse import quote
 
 import aiohttp
 
@@ -57,7 +58,7 @@ class GoogleCalendarRepository:
         while True:
             data = await self._request(
                 "GET",
-                f"/calendars/{calendar.id}/events",
+                f"/calendars/{quote(calendar.id, safe='')}/events",
                 params=params,
             )
 

--- a/tests/services/google_calendar/test_repository.py
+++ b/tests/services/google_calendar/test_repository.py
@@ -74,6 +74,47 @@ class TestFetchCalendars:
         assert calendars[1].summary == "mkuri"
 
 
+class TestFetchEventsWithSpecialCalendarId:
+    async def test_calendar_id_with_hash_is_url_encoded(self):
+        """Calendar IDs like 'ja.japanese#holiday@group.v.calendar.google.com'
+        contain '#' which must be percent-encoded in the URL path."""
+        repo = GoogleCalendarRepository(make_auth())
+        time_min = datetime(2026, 2, 23, 0, 0, tzinfo=JST)
+        time_max = datetime(2026, 3, 1, 0, 0, tzinfo=JST)
+
+        cal_id = "ja.japanese#holiday@group.v.calendar.google.com"
+        encoded_id = "ja.japanese%23holiday@group.v.calendar.google.com"
+
+        cal_list = {
+            "kind": "calendar#calendarList",
+            "items": [{"id": cal_id, "summary": "Holidays"}],
+        }
+        events_payload = {
+            "kind": "calendar#events",
+            "items": [
+                {
+                    "id": "ev1",
+                    "summary": "National Holiday",
+                    "status": "confirmed",
+                    "start": {"date": "2026-02-23"},
+                    "end": {"date": "2026-02-24"},
+                },
+            ],
+        }
+
+        with aioresponses() as m:
+            m.get(f"{API_BASE}/users/me/calendarList", payload=cal_list)
+            m.get(
+                re.compile(rf"{API_BASE}/calendars/{re.escape(encoded_id)}/events.*"),
+                payload=events_payload,
+            )
+            events = await repo.fetch_events(time_min=time_min, time_max=time_max)
+
+        assert len(events) == 1
+        assert events[0].summary == "National Holiday"
+        assert events[0].calendar.id == cal_id
+
+
 class TestFetchEvents:
     async def test_returns_events_from_all_calendars(self):
         repo = GoogleCalendarRepository(make_auth())


### PR DESCRIPTION
## Summary
- URL-encode calendar IDs when building the events endpoint path
- Calendar IDs like `ja.japanese#holiday@group.v.calendar.google.com` contain `#` which was interpreted as a URL fragment separator, causing 404 errors

## Test plan
- [x] Added test with `#`-containing calendar ID (`ja.japanese#holiday@group.v.calendar.google.com`)
- [x] All 6 Google Calendar repository tests pass
- [ ] Verify on deployment that holiday calendar events are fetched correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)